### PR TITLE
Factored out node label creation, now use label throughout UI

### DIFF
--- a/webapp/src/main/ui/src/app/home/views/deduplicateModal.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/deduplicateModal.tpl.html
@@ -2,7 +2,7 @@
     <div class="panel-heading">Candidate Duplicates</div>
     <div class="panel-body">
         <div class="deduplication-item" ng-repeat="dd in deduplications">
-            <label class="label label-default dedupe-label" ng-repeat="ent in dd.entities">{{ent.id}}</label>
+            <label class="label label-default dedupe-label" ng-repeat="ent in dd.entities">{{ent.label}}</label>
             <label class="label" ng-class="'label-' + getScoreClass(dd.score)">{{round(dd.score)}}</label>
             <button class="btn btn-sm btn-default" ng-click="toggleSelect(dd, $index)">{{getToggleClass(dd) === 'success' ? 'Remove' : 'Add'}}</button>
             <label class="deduplication-selection-icon label" ng-class="'label-' + getToggleClass(dd)"><i class="fa" ng-class="getToggleIconClass(dd)"></i></label>

--- a/webapp/src/main/ui/src/app/home/views/listView.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/listView.tpl.html
@@ -1,6 +1,6 @@
 <div class="list-body">
     <div ng-repeat="d in data" class="list-item" ng-class="{selected: selection.indexOf(d) >= 0}" ng-click="select(d, $event)">
-        <label class="label label-default label-entity">{{d.entity.id}}</label>
+        <label class="label label-default label-entity">{{d.entity.label}}</label>
         <label class="label" ng-class="'label-' + getScoreClass(d.score)">{{round(d.score)}}</label>
         <button ng-click="remove()(d)" class="rem btn btn-xs btn-danger"><i class="fa fa-minus"></i></button>
         <button ng-click="splitItem()(d)" class="btn btn-xs btn-success"><i class="fa fa-unlink"></i>Split</button>

--- a/webapp/src/main/ui/src/app/home/views/resolveModal.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/resolveModal.tpl.html
@@ -1,8 +1,8 @@
 <div class="resolve-modal panel panel-default">
-    <div class="panel-heading">{{entity.entity.id}}</div>
+    <div class="panel-heading">{{entity.entity.label}}</div>
     <div class="panel-body">
         <div class="resolution-item" ng-repeat="r in resolutions">
-            <label class="label label-default">{{r.entity.id}}</label>
+            <label class="label label-default">{{r.entity.label}}</label>
             <label class="label" ng-class="'label-' + getScoreClass(r.score)">{{round(r.score)}}</label>
             <button class="btn btn-sm btn-default" ng-click="toggleSelect(r)">{{getToggleClass(r) === 'success' ? 'Remove' : 'Add'}}</button>
             <label class="resolution-selection-icon label" ng-class="'label-' + getToggleClass(r)"><i class="fa" ng-class="getToggleIconClass(r)"></i></label>

--- a/webapp/src/main/ui/src/app/home/views/splitModal.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/splitModal.tpl.html
@@ -1,5 +1,5 @@
 <div class="split-modal panel panel-default">
-    <div class="panel-heading">Split - {{entity.entity.id}}</div>
+    <div class="panel-heading">Split - {{entity.entity.label}}</div>
     <div class="panel-body">
         <div class="original-entity">
             <div class="attrs">


### PR DESCRIPTION
This work is based off PR #21 

For testing, note that nodes in dialogs should all use a label, not an entity ID (assuming your data has a displayName or name sort of field). In particular, when you split or merge entities, the resulting additions to the list view also use the label. All dialog boxes use the label, as does the list view and header for the detail view.

The only place (I know of) where node ids will show up is in the merge/split dialogs for the edge fields. Fixing that seems related enough to better edge support throughout that I'm happy to save it for later.