### PR TITLE
Removed superfluous/incorrect multiplication by 100

### DIFF
--- a/webapp/src/main/ui/src/app/home/home.js
+++ b/webapp/src/main/ui/src/app/home/home.js
@@ -75,7 +75,7 @@ angular.module('bullseye.home', [])
                 var nodes = [];
                 $scope.selected.items.forEach(function(n) {
                     n.entities.forEach(function (e){
-                        nodes.push({entity: e, score: Math.round(100.0 * n.score)});
+                        nodes.push({entity: e, score: n.score});
                     });
                 });
                 $modalInstance.close(nodes);


### PR DESCRIPTION
In the dedupe modal the scores looked ok, but if you added one, the scores were 100 times too big. This change addresses this issue.