### PR TITLE
Enable item selection by clicking on the graph

### DIFF
--- a/webapp/src/main/ui/src/app/home/home.js
+++ b/webapp/src/main/ui/src/app/home/home.js
@@ -457,8 +457,13 @@ angular.module('bullseye.home', [])
                 });
             });
         };
-        $scope.select = function (d) {
-            console.log(d);
+        $scope.select = function (entityIds) {
+            _.each($scope.data.selection, function (d) { d.entity.group = 'unselected'; });
+            var entities = _.map(entityIds, function (entityId) {
+                return _.find($scope.data.network[0], { 'id': entityId });
+            });
+            _.each(entities, function (ent) { ent.group = 'selected'; });
+            $scope.data.selection = _.map(entities, function (ent) { return { 'entity': ent }; });
         };
         $scope.showNeighborhood = DataService.showNeighborhood;
         $scope.removeItem = DataService.removeItem;

--- a/webapp/src/main/ui/src/app/home/home.js
+++ b/webapp/src/main/ui/src/app/home/home.js
@@ -457,6 +457,9 @@ angular.module('bullseye.home', [])
                 });
             });
         };
+        $scope.select = function (d) {
+            console.log(d);
+        };
         $scope.showNeighborhood = DataService.showNeighborhood;
         $scope.removeItem = DataService.removeItem;
     }])
@@ -575,7 +578,8 @@ angular.module('bullseye.home', [])
             restrict: 'E',
             scope: {
                 data: '=',
-                selection: '='
+                selection: '=',
+                select: '&select'
             },
             link: function (scope, element, attrs) {
                 var viz,
@@ -587,10 +591,11 @@ angular.module('bullseye.home', [])
                     .style('position', 'relative')
                     .style('height', '100%')
                     .node();
-                // it seems to be a little tricky to get node selection to cause the item to be selected in the listView
-                // while unfortunate, for now, let's just turn off selection of nodes.
-                // they still highlight when you select one in the listView.
-                viz = new vis.Network(el, { nodes: nodes, edges: edges, options: { selectable: false } });
+                viz = new vis.Network(el, { nodes: nodes, edges: edges });
+                viz.on('select', function (properties) {
+                    scope.select()(properties.nodes);
+                    viz.selectEdges([]);
+                });
                 scope.$watch('data', function (data) {
                     var removeNodes = nodes.getIds();
                     var newNodeData = _.map(data[0], function(node) {

--- a/webapp/src/main/ui/src/app/home/home.tpl.html
+++ b/webapp/src/main/ui/src/app/home/home.tpl.html
@@ -3,7 +3,7 @@
         <div ng-include="'masthead/masthead.tpl.html'"></div>
     </div>
     <div>
-        <network-view data="data.network" selection="data.selection"></network-view>
+        <network-view data="data.network" selection="data.selection" select="select"></network-view>
         <div ng-if="data.raw.length === 0" class="no-data alert alert-info">Please select a starting node. <i class="fa fa-chevron-up"></i></div>
     </div>
     <div class="list-content" ng-show="data.raw.length > 0">

--- a/webapp/src/main/ui/src/app/home/home.tpl.html
+++ b/webapp/src/main/ui/src/app/home/home.tpl.html
@@ -3,7 +3,7 @@
         <div ng-include="'masthead/masthead.tpl.html'"></div>
     </div>
     <div>
-        <network-view data="data.network" selection="data.selection" select="select"></network-view>
+        <network-view data="data.network" select="select" selection="data.selection"></network-view>
         <div ng-if="data.raw.length === 0" class="no-data alert alert-info">Please select a starting node. <i class="fa fa-chevron-up"></i></div>
     </div>
     <div class="list-content" ng-show="data.raw.length > 0">
@@ -11,7 +11,7 @@
             <h3>Results</h3>
             <div class="num-results"><span class="badge">{{data.raw.length}}</span></div>
         </div>
-        <list-view data="data.raw" selection="data.selection" resolveitem="resolveItem" splititem="splitItem" showneighborhood="showNeighborhood" remove="removeItem"></list-view>
-        <detail-view mergeitems="mergeItems" ng-show="data.raw" data="data.selection" ></detail-view>
+        <list-view data="data.raw" select="select" selection="data.selection" resolveitem="resolveItem" splititem="splitItem" showneighborhood="showNeighborhood" remove="removeItem"></list-view>
+        <detail-view mergeitems="mergeItems" ng-show="data.raw" data="data.richSelection" ></detail-view>
     </div>
 </div>

--- a/webapp/src/main/ui/src/app/home/views/detailView.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/detailView.tpl.html
@@ -2,7 +2,7 @@
     <h3>{{getHeader()}}</h3>
     <div class="no-data alert alert-info" ng-if="data.length === 0"><i class="fa fa-chevron-left">Select an entity to view details</i></div>
     <div ng-if="data.length == 1" class="details-inner">
-        <div class="details-inner-cnt single" ng-repeat="(key, value) in data[0].entity.attrs">
+        <div class="details-inner-cnt single" ng-repeat="(key, value) in data[0].attrs">
             <label class="label label-default label-key">{{key}}</label>:
             <label class="label label-default label-value">{{value}}</label>
         </div>

--- a/webapp/src/main/ui/src/app/home/views/listView.tpl.html
+++ b/webapp/src/main/ui/src/app/home/views/listView.tpl.html
@@ -1,5 +1,5 @@
 <div class="list-body">
-    <div ng-repeat="d in data" class="list-item" ng-class="{selected: selection.indexOf(d) >= 0}" ng-click="select(d, $event)">
+    <div ng-repeat="d in data" class="list-item" ng-class="{selected: selection.indexOf(d.entity.id) >= 0}" ng-click="handleClick(d, $event)">
         <label class="label label-default label-entity">{{d.entity.id}}</label>
         <label class="label" ng-class="'label-' + getScoreClass(d.score)">{{round(d.score)}}</label>
         <button ng-click="remove()(d)" class="rem btn btn-xs btn-danger"><i class="fa fa-minus"></i></button>


### PR DESCRIPTION
Note that for viz.js, to select multiple nodes you have to "long-click" (i.e., hold down the click for a second on the additional nodes you want).

To test this, you should be able to select in the graph or the list any item and see all 3 panels update accordingly. You should be able to multi-select in the graph or list and see the other panels update accordingly. You should be able to merge and split as before (this is worth testing, because we pass the entities around a little bit between the panels).