### PR TITLE
Removed security roles, constraints, and login-config from web.xml

### DIFF
--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -12,29 +12,4 @@
     <listener>
         <listener-class>org.scalatra.servlet.ScalatraListener</listener-class>
     </listener>
-
-    <security-role>
-        <role-name>tomcat</role-name>
-    </security-role>
-
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>Wildcard means whole app requires authentication</web-resource-name>
-			<url-pattern>/*</url-pattern>
-			<http-method>GET</http-method>
-			<http-method>POST</http-method>
-		</web-resource-collection>
-		<auth-constraint>
-			<role-name>tomcat</role-name>
-		</auth-constraint>
-
-		<user-data-constraint>
-			<!-- transport-guarantee can be CONFIDENTIAL, INTEGRAL, or NONE -->
-			<transport-guarantee>NONE</transport-guarantee>
-		</user-data-constraint>
-	</security-constraint>
-
-	<login-config>
-		<auth-method>BASIC</auth-method>
-	</login-config>
 </web-app>


### PR DESCRIPTION
Our base install should get to assume no authentication, especially for a 'tomcat' role.
Installations that desire authentication should configure it themselves.

This addresses #27 