### PR TITLE
Remove auth config from base web.xml, update PADS to support non-logged in users

### DIFF
--- a/service/src/main/scala/org/oseraf/bullseye/service/DataService/PrincipalAwareDataService.scala
+++ b/service/src/main/scala/org/oseraf/bullseye/service/DataService/PrincipalAwareDataService.scala
@@ -52,19 +52,23 @@ trait PrincipalAwareDataService extends DataService {
   }
   private def isOK(p:Principal, entity:Entity):Boolean = {
     entity.attributes.get(AUTH_KEY) match {
-      case Some(pName) => pName == p.getName
+      case Some(pName) => p != null && pName == p.getName
       case _ => true //there is no Authorization key/value so this entity is globally available
     }
   }
   def merge(p:Principal, entityIds: Seq[EntityStore.ID], mergedEntity:BullsEyeEntity): BullsEyeEntity = {
     val visibleEdgeFilteredEntities = entityIds.flatMap(eId => getBullsEyeEntityDetails(p, eId))
-    val newMergedEntity = mergedEntity.copy(attrs=mergedEntity.attrs + (AUTH_KEY -> p.getName))
+    val newMergedEntity =
+      if (p == null) mergedEntity
+      else mergedEntity.copy(attrs=mergedEntity.attrs + (AUTH_KEY -> p.getName))
     super.merge(visibleEdgeFilteredEntities.map(_.id), newMergedEntity)
   }
   def split(p:Principal, entityId: EntityStore.ID, splitEntities:Seq[BullsEyeEntity]): Seq[BullsEyeEntity] = {
     getBullsEyeEntityDetails(p, entityId) match {
       case Some(ent) => {
-        val newSplitEntities = splitEntities.map(e => e.copy(attrs=e.attrs + (AUTH_KEY -> p.getName)))
+        val newSplitEntities =
+          if (p == null) splitEntities
+          else splitEntities.map(e => e.copy(attrs=e.attrs + (AUTH_KEY -> p.getName)))
         super.split(entityId, newSplitEntities)
       }
       case _ => List()

--- a/webapp/src/main/webapp/WEB-INF/web.xml
+++ b/webapp/src/main/webapp/WEB-INF/web.xml
@@ -12,29 +12,4 @@
     <listener>
         <listener-class>org.scalatra.servlet.ScalatraListener</listener-class>
     </listener>
-
-    <security-role>
-        <role-name>tomcat</role-name>
-    </security-role>
-
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>Wildcard means whole app requires authentication</web-resource-name>
-			<url-pattern>/*</url-pattern>
-			<http-method>GET</http-method>
-			<http-method>POST</http-method>
-		</web-resource-collection>
-		<auth-constraint>
-			<role-name>tomcat</role-name>
-		</auth-constraint>
-
-		<user-data-constraint>
-			<!-- transport-guarantee can be CONFIDENTIAL, INTEGRAL, or NONE -->
-			<transport-guarantee>NONE</transport-guarantee>
-		</user-data-constraint>
-	</security-constraint>
-
-	<login-config>
-		<auth-method>BASIC</auth-method>
-	</login-config>
 </web-app>


### PR DESCRIPTION
This addresses #29 

Removed the security-role, security-constraint, and login-config from web.xml, so that the default install doesn't expect any logging in (and, especially, doesn't expect it to be in the 'tomcat' role). Updated the PrincipalAwareDataService so that if you don't require login, users can still merge and split users (were getting a NullPointerException prior to this). Note that if you aren't logged in, all your created entities (merge/split) will have global access, but if you are logged in, you still create nodes that only you can see. This can be tested using the basic tomcat-users file and alternating logins between the 'tomcat' and 'both' users.